### PR TITLE
DataStore file is read-only in build

### DIFF
--- a/modules/data/DataStore.js
+++ b/modules/data/DataStore.js
@@ -1,11 +1,12 @@
-var fs = require("fs");
-var path = require("path");
-var SQL = require("sql.js");
+const fs = require("fs");
+const path = require("path");
+const SQL = require("sql.js");
+const app = require("electron").remote.app;
 
 var method = DataStore.prototype;
 
 function DataStore(storeFile = "./store.db") {
-    this._dbFile = path.join(__dirname, storeFile);
+    this._dbFile = path.join(app.getPath("userData"), storeFile);
 }
 
 method.OpenDB = function() {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "build": "build -mwl --x64 --ia32",
-    "build-windows": "build --windows --x64 --ia32",
-    "build-mac": "build --mac --x64 --ia32",
-    "build-linux": "build --linux --x64 --ia32"
+    "build": "build -mwl --x64 --ia32 --publish never",
+    "build-windows": "build --windows --x64 --ia32 --publish never",
+    "build-mac": "build --mac --x64 --ia32 --publish never",
+    "build-linux": "build --linux --x64 --ia32 --publish never"
   },
   "build": {
     "appId": "nz.crook.matt.interflare",


### PR DESCRIPTION
**Addresssed**: #7 
**Included in this PR**:
- DataStore was moved into the appdata/os-equiv folder to make it writable
- Jenkinsfile was updated to reflect the changes made in 2dbe5ca, that were modified after this branch was created